### PR TITLE
Added feature to limit the number of kernels in memory during estimation

### DIFF
--- a/src/PointProcessDecoder.Core/Encoder/ClusterlessMarkEncoder.cs
+++ b/src/PointProcessDecoder.Core/Encoder/ClusterlessMarkEncoder.cs
@@ -70,6 +70,7 @@ public class ClusterlessMarkEncoder : IEncoder
         double[] markBandwidth,
         IStateSpace stateSpace,
         double? distanceThreshold = null,
+        int? kernelLimit = null,
         Device? device = null,
         ScalarType? scalarType = null
     )
@@ -98,8 +99,8 @@ public class ClusterlessMarkEncoder : IEncoder
             case EstimationMethod.KernelDensity:
 
                 _observationEstimation = new KernelDensity(
-                    observationBandwidth, 
-                    _stateSpace.Dimensions, 
+                    bandwidth: observationBandwidth, 
+                    dimensions: _stateSpace.Dimensions, 
                     device: device,
                     scalarType: scalarType
                 );
@@ -107,15 +108,15 @@ public class ClusterlessMarkEncoder : IEncoder
                 for (int i = 0; i < _markChannels; i++)
                 {
                     _channelEstimation[i] = new KernelDensity(
-                        observationBandwidth, 
-                        _stateSpace.Dimensions, 
+                        bandwidth: observationBandwidth, 
+                        dimensions: _stateSpace.Dimensions, 
                         device: device,
                         scalarType: scalarType
                     );
 
                     _markEstimation[i] = new KernelDensity(
-                        markBandwidth, 
-                        _markDimensions, 
+                        bandwidth: markBandwidth, 
+                        dimensions: _markDimensions, 
                         device: device,
                         scalarType: scalarType
                     );
@@ -129,9 +130,10 @@ public class ClusterlessMarkEncoder : IEncoder
 
             case EstimationMethod.KernelCompression:
                 _observationEstimation = new KernelCompression(
-                    observationBandwidth, 
-                    _stateSpace.Dimensions, 
-                    distanceThreshold,
+                    bandwidth: observationBandwidth, 
+                    dimensions: _stateSpace.Dimensions, 
+                    distanceThreshold: distanceThreshold,
+                    kernelLimit: kernelLimit,
                     device: device,
                     scalarType: scalarType
                 );
@@ -142,17 +144,19 @@ public class ClusterlessMarkEncoder : IEncoder
                 for (int i = 0; i < _markChannels; i++)
                 {
                     _channelEstimation[i] = new KernelCompression(
-                        observationBandwidth, 
-                        _stateSpace.Dimensions, 
-                        distanceThreshold,
+                        bandwidth: observationBandwidth, 
+                        dimensions: _stateSpace.Dimensions, 
+                        distanceThreshold: distanceThreshold,
+                        kernelLimit: kernelLimit,
                         device: device,
                         scalarType: scalarType
                     );
 
                     _markEstimation[i] = new KernelCompression(
-                        bandwidth, 
-                        jointDimensions, 
-                        distanceThreshold,
+                        bandwidth: bandwidth, 
+                        dimensions: jointDimensions, 
+                        distanceThreshold: distanceThreshold,
+                        kernelLimit: kernelLimit,
                         device: device,
                         scalarType: scalarType
                     );

--- a/src/PointProcessDecoder.Core/Encoder/SortedSpikeEncoder.cs
+++ b/src/PointProcessDecoder.Core/Encoder/SortedSpikeEncoder.cs
@@ -54,7 +54,8 @@ public class SortedSpikeEncoder : IEncoder
         double[] bandwidth,
         int nUnits,
         IStateSpace stateSpace,
-        double? distanceThreshold = null, 
+        double? distanceThreshold = null,
+        int? kernelLimit = null,
         Device? device = null,
         ScalarType? scalarType = null
     )
@@ -71,10 +72,11 @@ public class SortedSpikeEncoder : IEncoder
         _nUnits = nUnits;
         
         _observationEstimation = GetEstimationMethod(
-            estimationMethod, 
-            bandwidth, 
-            _stateSpace.Dimensions, 
-            distanceThreshold,
+            estimationMethod: estimationMethod, 
+            bandwidth: bandwidth, 
+            dimensions: _stateSpace.Dimensions, 
+            distanceThreshold: distanceThreshold,
+            kernelLimit: kernelLimit,
             device: device,
             scalarType: scalarType
         );
@@ -84,10 +86,11 @@ public class SortedSpikeEncoder : IEncoder
         for (int i = 0; i < _nUnits; i++)
         {
             _unitEstimation[i] = GetEstimationMethod(
-                estimationMethod, 
-                bandwidth, 
-                _stateSpace.Dimensions, 
-                distanceThreshold,
+                estimationMethod: estimationMethod, 
+                bandwidth: bandwidth, 
+                dimensions: _stateSpace.Dimensions, 
+                distanceThreshold: distanceThreshold,
+                kernelLimit: kernelLimit,
                 device: device,
                 scalarType: scalarType
             );
@@ -101,6 +104,7 @@ public class SortedSpikeEncoder : IEncoder
         double[] bandwidth, 
         int dimensions, 
         double? distanceThreshold = null,
+        int? kernelLimit = null,
         Device? device = null,
         ScalarType? scalarType = null
     )
@@ -108,15 +112,16 @@ public class SortedSpikeEncoder : IEncoder
         return estimationMethod switch
         {
             EstimationMethod.KernelDensity => new KernelDensity(
-                bandwidth, 
-                dimensions, 
+                bandwidth: bandwidth, 
+                dimensions: dimensions, 
                 device: device,
                 scalarType: scalarType
             ),
             EstimationMethod.KernelCompression => new KernelCompression(
-                bandwidth, 
-                dimensions, 
-                distanceThreshold, 
+                bandwidth: bandwidth, 
+                dimensions: dimensions, 
+                distanceThreshold: distanceThreshold,
+                kernelLimit: kernelLimit,
                 device: device,
                 scalarType: scalarType
             ),

--- a/src/PointProcessDecoder.Core/PointProcessModel.cs
+++ b/src/PointProcessDecoder.Core/PointProcessModel.cs
@@ -81,6 +81,7 @@ public class PointProcessModel : IModel
                 markBandwidth: markBandwidth ?? observationBandwidth,
                 stateSpace: _stateSpace,
                 distanceThreshold: distanceThreshold,
+                kernelLimit: kernelLimit,
                 device: _device,
                 scalarType: _scalarType
             ),
@@ -89,7 +90,8 @@ public class PointProcessModel : IModel
                 bandwidth: observationBandwidth,
                 nUnits: nUnits ?? 1,
                 stateSpace: _stateSpace,
-                distanceThreshold: distanceThreshold, 
+                distanceThreshold: distanceThreshold,
+                kernelLimit: kernelLimit,
                 device: _device,
                 scalarType: _scalarType
             ),

--- a/src/PointProcessDecoder.Core/PointProcessModel.cs
+++ b/src/PointProcessDecoder.Core/PointProcessModel.cs
@@ -50,6 +50,7 @@ public class PointProcessModel : IModel
         double? distanceThreshold = null,
         bool ignoreNoSpikes = false,
         double? sigmaRandomWalk = null,
+        int? kernelLimit = null,
         Device? device = null,
         ScalarType? scalarType = null
     )

--- a/test/PointProcessDecoder.Cpu.Test/TestModel.cs
+++ b/test/PointProcessDecoder.Cpu.Test/TestModel.cs
@@ -318,7 +318,7 @@ public class TestModel
     [TestMethod]
     public void TestPointProcessModelClusterlessMarksRandomWalkCompressionRealData2DBatchedProcessing()
     {
-        string positionFile = "../../../../data/positions_2D.bin";
+        string positionFile = "../../../../data/position.bin";
         string marksFile = "../../../../data/marks.bin";
 
         int markDimensions = 4;
@@ -369,7 +369,7 @@ public class TestModel
     [TestMethod]
     public void CompareClusterlessEncodingBatchSizes()
     {
-        string positionFile = "../../../../data/positions_2D.bin";
+        string positionFile = "../../../../data/position.bin";
         string marksFile = "../../../../data/marks.bin";
 
         int markDimensions = 4;
@@ -454,7 +454,7 @@ public class TestModel
     [TestMethod]
     public void CompareSortedUnitsEncodingBatchSizes()
     {
-        string positionFile = "../../../../data/positions_2D.bin";
+        string positionFile = "../../../../data/position.bin";
         string spikesFile = "../../../../data/spike_counts.bin";
 
         var (position, spikingData) = InitializeRealData(
@@ -534,7 +534,7 @@ public class TestModel
     [TestMethod]
     public void TestKernelLimit()
     {
-        string positionFile = "../../../../data/positions_2D.bin";
+        string positionFile = "../../../../data/position.bin";
         string marksFile = "../../../../data/marks.bin";
 
         int markDimensions = 4;
@@ -608,7 +608,7 @@ public class TestModel
             );
         }
 
-        var kernelCountsLimited = pointProcessModel.Encoder.Estimations.Select(e => e.Kernels.shape[0]).ToList();
+        var kernelCountsLimited = pointProcessModelLimited.Encoder.Estimations.Select(e => e.Kernels.shape[0]).ToList();
 
         Assert.IsTrue(kernelCountsLimited.All(k => k <= 100));
     }

--- a/test/PointProcessDecoder.Cpu.Test/TestModel.cs
+++ b/test/PointProcessDecoder.Cpu.Test/TestModel.cs
@@ -530,4 +530,86 @@ public class TestModel
 
         Assert.AreEqual(prediction1, prediction2);
     }
+
+    [TestMethod]
+    public void TestKernelLimit()
+    {
+        string positionFile = "../../../../data/positions_2D.bin";
+        string marksFile = "../../../../data/marks.bin";
+
+        int markDimensions = 4;
+        int markChannels = 28;
+
+        var (position, marks) = InitializeRealData(
+            positionFile: positionFile,
+            marksFile: marksFile
+        );
+
+        position = position.reshape(-1, 2);
+        marks = marks.reshape(position.shape[0], markDimensions, markChannels);
+
+        var pointProcessModel = new PointProcessModel(
+            estimationMethod: EstimationMethod.KernelCompression,
+            transitionsType: TransitionsType.RandomWalk,
+            encoderType: Core.Encoder.EncoderType.ClusterlessMarkEncoder,
+            decoderType: Core.Decoder.DecoderType.StateSpaceDecoder,
+            stateSpaceType: Core.StateSpace.StateSpaceType.DiscreteUniformStateSpace,
+            likelihoodType: Core.Likelihood.LikelihoodType.Clusterless,
+            minStateSpace: [0, 0],
+            maxStateSpace: [120, 120],
+            stepsStateSpace: [50, 50],
+            observationBandwidth: [2, 2],
+            stateSpaceDimensions: 2,
+            markDimensions: markDimensions,
+            markChannels: markChannels,
+            markBandwidth: [1, 1, 1, 1],
+            distanceThreshold: 1.5,
+            sigmaRandomWalk: 5
+        );
+
+        int nBatches = 10;
+        int batchSize = 1000;
+
+        for (int i = 0; i < nBatches; i++) {
+            pointProcessModel.Encode(
+                position[TensorIndex.Slice(i * batchSize, (i + 1) * batchSize)],
+                marks[TensorIndex.Slice(i * batchSize, (i + 1) * batchSize)]
+            );
+        }
+
+        var kernelCounts = pointProcessModel.Encoder.Estimations.Select(e => e.Kernels.shape[0]).ToList();
+
+        Assert.IsTrue(kernelCounts.Any(k => k > 100));
+
+        var pointProcessModelLimited = new PointProcessModel(
+            estimationMethod: EstimationMethod.KernelCompression,
+            transitionsType: TransitionsType.RandomWalk,
+            encoderType: Core.Encoder.EncoderType.ClusterlessMarkEncoder,
+            decoderType: Core.Decoder.DecoderType.StateSpaceDecoder,
+            stateSpaceType: Core.StateSpace.StateSpaceType.DiscreteUniformStateSpace,
+            likelihoodType: Core.Likelihood.LikelihoodType.Clusterless,
+            minStateSpace: [0, 0],
+            maxStateSpace: [120, 120],
+            stepsStateSpace: [50, 50],
+            observationBandwidth: [2, 2],
+            stateSpaceDimensions: 2,
+            markDimensions: markDimensions,
+            markChannels: markChannels,
+            markBandwidth: [1, 1, 1, 1],
+            distanceThreshold: 1.5,
+            sigmaRandomWalk: 5,
+            kernelLimit: 100
+        );
+
+        for (int i = 0; i < nBatches; i++) {
+            pointProcessModelLimited.Encode(
+                position[TensorIndex.Slice(i * batchSize, (i + 1) * batchSize)],
+                marks[TensorIndex.Slice(i * batchSize, (i + 1) * batchSize)]
+            );
+        }
+
+        var kernelCountsLimited = pointProcessModel.Encoder.Estimations.Select(e => e.Kernels.shape[0]).ToList();
+
+        Assert.IsTrue(kernelCountsLimited.All(k => k <= 100));
+    }
 }

--- a/test/PointProcessDecoder.Test.Common/EstimationUtilities.cs
+++ b/test/PointProcessDecoder.Test.Common/EstimationUtilities.cs
@@ -132,7 +132,7 @@ public static class EstimationUtilities
         var placeFieldCenters2D = concat([zeros_like(placeFieldCenters), placeFieldCenters], dim: 1);
 
         var spikingData = Simulate.SpikesAtPosition(position1DExpanded, placeFieldCenters2D, placeFieldRadius, firingThreshold, seed);
-        var positionKDE = new KernelDensity(bandwidth, numDimensions, device);
+        var positionKDE = new KernelDensity(bandwidth, numDimensions, device: device);
         positionKDE.Fit(position1D.to_type(ScalarType.Float64));
         var positionDensity = positionKDE.Evaluate(
             new double[] { yMin }, 


### PR DESCRIPTION
This pull request introduces the `kernelLimit` parameter to several classes and methods in the `PointProcessDecoder.Core` project to control the maximum number of kernels maintained in memory. Additionally, it includes a new test method to validate the `kernelLimit` functionality.