### PR TITLE
Fix issue with failing to pass kernel limit parameter to density estimation constructor.

### DIFF
--- a/src/PointProcessDecoder.Core/Configuration/PointProcessModelConfiguration.cs
+++ b/src/PointProcessDecoder.Core/Configuration/PointProcessModelConfiguration.cs
@@ -98,6 +98,11 @@ public class PointProcessModelConfiguration
     public double? SigmaRandomWalk { get; set; }
 
     /// <summary>
+    /// The kernel limit of the model.
+    /// </summary>
+    public int? KernelLimit { get; set; }
+
+    /// <summary>
     /// The scalar type of the model.
     /// </summary>
     public ScalarType? ScalarType { get; set; }

--- a/src/PointProcessDecoder.Core/Encoder/ClusterlessMarkEncoder.cs
+++ b/src/PointProcessDecoder.Core/Encoder/ClusterlessMarkEncoder.cs
@@ -98,6 +98,7 @@ public class ClusterlessMarkEncoder : ModelComponent, IEncoder
                 _observationEstimation = new KernelDensity(
                     bandwidth: observationBandwidth, 
                     dimensions: _stateSpace.Dimensions, 
+                    kernelLimit: kernelLimit,
                     device: device,
                     scalarType: scalarType
                 );
@@ -106,7 +107,8 @@ public class ClusterlessMarkEncoder : ModelComponent, IEncoder
                 {
                     _markEstimation[i] = new KernelDensity(
                         bandwidth: bandwidth, 
-                        dimensions: jointDimensions, 
+                        dimensions: jointDimensions,
+                        kernelLimit: kernelLimit,
                         device: device,
                         scalarType: scalarType
                     );

--- a/src/PointProcessDecoder.Core/Encoder/ClusterlessMarkEncoder.cs
+++ b/src/PointProcessDecoder.Core/Encoder/ClusterlessMarkEncoder.cs
@@ -34,7 +34,7 @@ public class ClusterlessMarkEncoder : ModelComponent, IEncoder
     private Tensor _markIntensities = empty(0);
     private Tensor _channelIntensities = empty(0);
     private Tensor _observationDensity = empty(0);
-    private Tensor[] _channelEstimates = [];
+    private readonly Tensor[] _channelEstimates = [];
 
     private Tensor _spikeCounts = empty(0);
     private Tensor _samples = empty(0);

--- a/src/PointProcessDecoder.Core/Encoder/SortedSpikeEncoder.cs
+++ b/src/PointProcessDecoder.Core/Encoder/SortedSpikeEncoder.cs
@@ -112,6 +112,7 @@ public class SortedSpikeEncoder : ModelComponent, IEncoder
             EstimationMethod.KernelDensity => new KernelDensity(
                 bandwidth: bandwidth, 
                 dimensions: dimensions, 
+                kernelLimit: kernelLimit,
                 device: device,
                 scalarType: scalarType
             ),

--- a/src/PointProcessDecoder.Core/PointProcessModel.cs
+++ b/src/PointProcessDecoder.Core/PointProcessModel.cs
@@ -181,6 +181,7 @@ public class PointProcessModel : ModelBase, IModel
             DistanceThreshold = distanceThreshold,
             IgnoreNoSpikes = ignoreNoSpikes,
             SigmaRandomWalk = sigmaRandomWalk,
+            KernelLimit = kernelLimit,
             ScalarType = scalarType
         };
     }
@@ -272,6 +273,7 @@ public class PointProcessModel : ModelBase, IModel
             distanceThreshold: configuration.DistanceThreshold,
             ignoreNoSpikes: configuration.IgnoreNoSpikes,
             sigmaRandomWalk: configuration.SigmaRandomWalk,
+            kernelLimit: configuration.KernelLimit,
             device: device,
             scalarType: configuration.ScalarType
         );


### PR DESCRIPTION
This pull request introduces a new property `KernelLimit` to the `PointProcessModelConfiguration` and integrates it into various classes and methods across the codebase. The most important changes include adding the `KernelLimit` property, updating constructors, and modifying methods to utilize this new property.

### Key Changes:

#### Addition of `KernelLimit` Property:
* [`src/PointProcessDecoder.Core/Configuration/PointProcessModelConfiguration.cs`](diffhunk://#diff-85e5eba30ef0a0799ffd869551f6e839fbe1bc4587a55263340fa223b213ac0bR100-R104): Added the `KernelLimit` property to the `PointProcessModelConfiguration` class.

#### Updates to `ClusterlessMarkEncoder`:
* [`src/PointProcessDecoder.Core/Encoder/ClusterlessMarkEncoder.cs`](diffhunk://#diff-fc06aaf74a9ac5ca8b89ca2a5a56fd158c8a070caa869ee7fe653526c355ec03R101): Added the `kernelLimit` parameter to the `KernelDensity` constructor calls within the `ClusterlessMarkEncoder` class. [[1]](diffhunk://#diff-fc06aaf74a9ac5ca8b89ca2a5a56fd158c8a070caa869ee7fe653526c355ec03R101) [[2]](diffhunk://#diff-fc06aaf74a9ac5ca8b89ca2a5a56fd158c8a070caa869ee7fe653526c355ec03R111)
* [`src/PointProcessDecoder.Core/Encoder/ClusterlessMarkEncoder.cs`](diffhunk://#diff-fc06aaf74a9ac5ca8b89ca2a5a56fd158c8a070caa869ee7fe653526c355ec03L37-R37): Changed `_channelEstimates` to be a readonly field.

#### Updates to `SortedSpikeEncoder`:
* [`src/PointProcessDecoder.Core/Encoder/SortedSpikeEncoder.cs`](diffhunk://#diff-05ca089dff73d322da1a981c407a75d14fa74364e57dac0f90d7df80623549b7R115): Added the `kernelLimit` parameter to the `KernelDensity` constructor call within the `GetEstimationMethod` method.

#### Updates to `PointProcessModel`:
* [`src/PointProcessDecoder.Core/PointProcessModel.cs`](diffhunk://#diff-0bb0ed907cf9d9f8fc4cdb5110ca92e7dd219782182e8a449f28b356d551ea5aR184): Added the `KernelLimit` parameter to the `PointProcessModel` constructor and the `Save` method. [[1]](diffhunk://#diff-0bb0ed907cf9d9f8fc4cdb5110ca92e7dd219782182e8a449f28b356d551ea5aR184) [[2]](diffhunk://#diff-0bb0ed907cf9d9f8fc4cdb5110ca92e7dd219782182e8a449f28b356d551ea5aR276)