### PR TITLE
Updated likelihood functions

### DIFF
--- a/src/PointProcessDecoder.Core/Likelihood/ClusterlessLikelihood.cs
+++ b/src/PointProcessDecoder.Core/Likelihood/ClusterlessLikelihood.cs
@@ -52,10 +52,13 @@ public class ClusterlessLikelihood(
                 .unsqueeze(1)
                 .exp();
         }
-
+        
         likelihood = likelihood
-            .sum(dim: 0)
-            .exp();
+            .sum(dim: 0);
+
+        likelihood -= likelihood.max(dim: -1, keepdim: true).values;
+
+        likelihood = likelihood.exp();
 
         likelihood /= likelihood
             .sum(dim: -1, keepdim: true);

--- a/src/PointProcessDecoder.Core/Likelihood/PoissonLikelihood.cs
+++ b/src/PointProcessDecoder.Core/Likelihood/PoissonLikelihood.cs
@@ -50,11 +50,16 @@ public class PoissonLikelihood(
             * intensity;
         
         if (!_ignoreNoSpikes) {
-            likelihood -= intensity.exp();
+            likelihood -= intensity
+                .exp();
         }
 
         likelihood = likelihood
-            .sum(dim: 1)
+            .sum(dim: 1);
+
+        likelihood -= likelihood.max(dim: -1, keepdim: true).values;
+
+        likelihood = likelihood
             .exp();
 
         likelihood /= likelihood


### PR DESCRIPTION
# Summary

This pull request includes changes to the likelihood calculation methods in `ClusterlessLikelihood.cs` and `PoissonLikelihood.cs` to improve numerical stability by normalizing the likelihood values before exponentiation.

# Changes

* [`src/PointProcessDecoder.Core/Likelihood/ClusterlessLikelihood.cs`](diffhunk://#diff-917dfa9f769103aa49af973dd8c084d4f66cb01378abf161ca42ae971a67b501L57-R61): Modified the `likelihood` calculation to normalize values by subtracting the maximum value before applying the exponential function.
* [`src/PointProcessDecoder.Core/Likelihood/PoissonLikelihood.cs`](diffhunk://#diff-f4d5a8cc6f1db8fc534b266df364c244699d9758806391c0efc31fc3fe40aa6eL53-R62): Added normalization to the `likelihood` calculation by subtracting the maximum value before applying the exponential function.