### PR TITLE
Improved `Decode` method and updated interfaces with additional properties

### DIFF
--- a/src/PointProcessDecoder.Core/Decoder/StateSpaceDecoder.cs
+++ b/src/PointProcessDecoder.Core/Decoder/StateSpaceDecoder.cs
@@ -77,11 +77,11 @@ public class StateSpaceDecoder : ModelComponent, IDecoder
     }
 
     /// <inheritdoc/>
-    public Tensor Decode(Tensor inputs, Tensor likelihood)
+    public Tensor Decode(Tensor likelihood)
     {
         using var _ = NewDisposeScope();
 
-        var outputShape = new long[] { inputs.size(0) }
+        var outputShape = new long[] { likelihood.size(0) }
             .Concat(_stateSpace.Shape)
             .ToArray();
 
@@ -95,7 +95,7 @@ public class StateSpaceDecoder : ModelComponent, IDecoder
             output[0] = _posterior.reshape(_stateSpace.Shape);
         }
 
-        for (int i = 1; i < inputs.size(0); i++)
+        for (int i = 1; i < likelihood.size(0); i++)
         {
             _posterior = (_stateTransitions.Transitions.matmul(_posterior) * likelihood[i])
                 .nan_to_num()

--- a/src/PointProcessDecoder.Core/Decoder/StateSpaceDecoder.cs
+++ b/src/PointProcessDecoder.Core/Decoder/StateSpaceDecoder.cs
@@ -87,15 +87,17 @@ public class StateSpaceDecoder : ModelComponent, IDecoder
 
         var output = zeros(outputShape, dtype: _scalarType, device: _device);
 
+        var startIndex = 0;
+
         if (_posterior.numel() == 0) {
             _posterior = (_initialState * likelihood[0])
                 .nan_to_num()
                 .clamp_min(_eps);
             _posterior /= _posterior.sum();
-            output[0] = _posterior.reshape(_stateSpace.Shape);
+            startIndex++;
         }
 
-        for (int i = 1; i < likelihood.size(0); i++)
+        for (int i = startIndex; i < likelihood.size(0); i++)
         {
             _posterior = (_stateTransitions.Transitions.matmul(_posterior) * likelihood[i])
                 .nan_to_num()

--- a/src/PointProcessDecoder.Core/Encoder/SortedSpikeEncoder.cs
+++ b/src/PointProcessDecoder.Core/Encoder/SortedSpikeEncoder.cs
@@ -160,11 +160,9 @@ public class SortedSpikeEncoder : ModelComponent, IEncoder
 
         _rates = _spikeCounts.log() - _samples.log();
 
-        var inputMask = inputs.to_type(ScalarType.Bool);
-
         for (int i = 0; i < _nUnits; i++)
         {
-            _unitEstimation[i].Fit(observations[inputMask[TensorIndex.Colon, i]]);
+            _unitEstimation[i].Fit(observations.repeat_interleave(inputs[TensorIndex.Colon, i], dim: 0));
         }
 
         _updateIntensities = true;

--- a/src/PointProcessDecoder.Core/IDecoder.cs
+++ b/src/PointProcessDecoder.Core/IDecoder.cs
@@ -23,10 +23,9 @@ public interface IDecoder : IModelComponent
     public IStateTransitions Transitions { get; }
 
     /// <summary>
-    /// Decodes the observations into the latent state based on the inputs and the likelihood.
+    /// Decodes the observations into the latent state based on the likelihood of the data.
     /// </summary>
-    /// <param name="input"></param>
     /// <param name="likelihood"></param>
     /// <returns></returns>
-    public Tensor Decode(Tensor input, Tensor likelihood);
+    public Tensor Decode(Tensor likelihood);
 }

--- a/src/PointProcessDecoder.Core/ILikelihood.cs
+++ b/src/PointProcessDecoder.Core/ILikelihood.cs
@@ -13,6 +13,11 @@ public interface ILikelihood : IModelComponent
     public Likelihood.LikelihoodType LikelihoodType { get; }
 
     /// <summary>
+    /// Whether to ignore the contribution of units or channels with no spikes to the likelihood.
+    /// </summary>
+    public bool IgnoreNoSpikes { get; set; }
+
+    /// <summary>
     /// Measures the likelihood of the model given the inputs and the intensities.
     /// </summary>
     /// <param name="inputs"></param>

--- a/src/PointProcessDecoder.Core/IStateSpace.cs
+++ b/src/PointProcessDecoder.Core/IStateSpace.cs
@@ -18,6 +18,11 @@ public interface IStateSpace : IModelComponent
     public Tensor Points { get; }
 
     /// <summary>
+    /// The axes points of the state space.
+    /// </summary>
+    public Tensor AxesPoints { get; }
+
+    /// <summary>
     /// The shape of the state space.
     /// </summary>
     public long[] Shape { get; }

--- a/src/PointProcessDecoder.Core/PointProcessModel.cs
+++ b/src/PointProcessDecoder.Core/PointProcessModel.cs
@@ -206,7 +206,7 @@ public class PointProcessModel : ModelBase, IModel
     {
         var conditionalIntensities = _encoderModel.Evaluate(inputs);
         var likelihood = _likelihood.Likelihood(inputs, conditionalIntensities);
-        return _decoderModel.Decode(inputs, likelihood);
+        return _decoderModel.Decode(likelihood);
     }
 
     /// <inheritdoc/>

--- a/src/PointProcessDecoder.Core/StateSpace/DiscreteUniformStateSpace.cs
+++ b/src/PointProcessDecoder.Core/StateSpace/DiscreteUniformStateSpace.cs
@@ -26,6 +26,9 @@ public class DiscreteUniformStateSpace : ModelComponent, IStateSpace
     /// <inheritdoc/>
     public Tensor Points => _points;
 
+    private readonly Tensor _axesPoints;
+    public Tensor AxesPoints => _axesPoints;
+
     private readonly long[] _shape;
     /// <inheritdoc/>
     public long[] Shape => _shape;
@@ -57,8 +60,28 @@ public class DiscreteUniformStateSpace : ModelComponent, IStateSpace
         _dimensions = dimensions;
         _device = device ?? CPU;
         _scalarType = scalarType ?? ScalarType.Float32;
+        _axesPoints = ComputeAxesPoints(min, max, steps, _device, _scalarType);
         _points = ComputeDiscreteUniformStateSpace(min, max, steps, _device, _scalarType);
         _shape = steps;
+    }
+
+    public static Tensor ComputeAxesPoints(
+        double[] min,
+        double[] max,
+        long[] steps,
+        Device device,
+        ScalarType scalarType
+    )
+    {
+        using var _ = NewDisposeScope();
+        var dims = min.Length;
+        var axesPoints = new Tensor[dims];
+        for (int i = 0; i < dims; i++)
+        {
+            axesPoints[i] = linspace(min[i], max[i], steps[i], dtype: scalarType, device: device);
+        }
+        return vstack(axesPoints)
+            .MoveToOuterDisposeScope();
     }
 
     /// <summary>

--- a/test/PointProcessDecoder.Cpu.Test/TestModel.cs
+++ b/test/PointProcessDecoder.Cpu.Test/TestModel.cs
@@ -462,7 +462,7 @@ public class TestModel
 
         position = position.reshape(-1, 2);
         spikingData = spikingData.reshape(position.shape[0], -1)
-            .to_type(ScalarType.Bool);
+            .to_type(ScalarType.Int32);
         var numNeurons = (int)spikingData.shape[1];
 
         var pointProcessModel = new PointProcessModel(


### PR DESCRIPTION
This PR focuses on improving the `Decode` method and adding new properties to interfaces. The most important changes include modifying the `Decode` method to remove the `inputs` parameter, adding new properties to interfaces and classes, and updating the encoding logic in the `SortedSpikeEncoder` class to use integer spike counts as inputs instead of boolean values.

### Simplification of `Decode` method:
* [`src/PointProcessDecoder.Core/Decoder/StateSpaceDecoder.cs`](diffhunk://#diff-881827a7dc7090b0ef7a81113a6d2c592a2c264224d4b80a84c1d3043422cacbL80-R100): Modified the `Decode` method to remove the `inputs` parameter and updated the logic accordingly.
* [`src/PointProcessDecoder.Core/IDecoder.cs`](diffhunk://#diff-af70ec81a35dedb2cd43a8fa56d8f67d5eff0c70aaa9d042c544768b372fc83bL26-R30): Updated the `Decode` method signature to remove the `inputs` parameter.
* [`src/PointProcessDecoder.Core/PointProcessModel.cs`](diffhunk://#diff-0bb0ed907cf9d9f8fc4cdb5110ca92e7dd219782182e8a449f28b356d551ea5aL209-R209): Updated the `Decode` method call to remove the `inputs` parameter.

### Addition of new properties:
* [`src/PointProcessDecoder.Core/ILikelihood.cs`](diffhunk://#diff-740e700997f34bfc8aa490c3a4722b70ab3c68f3773fd833a39e016af56c234cR15-R19): Added the `IgnoreNoSpikes` property to indicate whether to ignore units or channels with no spikes.
* [`src/PointProcessDecoder.Core/IStateSpace.cs`](diffhunk://#diff-f41e0423e0e749c706b4950a5c76a1510e04d1463095da9a2c19edab7b5f80f5R20-R24): Added the `AxesPoints` property to represent the axes points of the state space.
* [`src/PointProcessDecoder.Core/StateSpace/DiscreteUniformStateSpace.cs`](diffhunk://#diff-2575acbc2f8dfb16128b906d8cbc31f8b6328199f79450de5f65894e662d73e9R29-R31): Added the `AxesPoints` property and its computation in the constructor. [[1]](diffhunk://#diff-2575acbc2f8dfb16128b906d8cbc31f8b6328199f79450de5f65894e662d73e9R29-R31) [[2]](diffhunk://#diff-2575acbc2f8dfb16128b906d8cbc31f8b6328199f79450de5f65894e662d73e9R63-R86)

### Update to encoding logic:
* [`src/PointProcessDecoder.Core/Encoder/SortedSpikeEncoder.cs`](diffhunk://#diff-05ca089dff73d322da1a981c407a75d14fa74364e57dac0f90d7df80623549b7L163-R165): Updated the encoding logic to use `repeat_interleave` instead of a boolean mask for fitting unit estimation.

### Test updates:
* [`test/PointProcessDecoder.Cpu.Test/TestModel.cs`](diffhunk://#diff-68c8411592f83f6bbf05eba80d2acfffd18c4cf1c3183ab65e3ca1c45456dc17L465-R465): Changed the data type conversion in `CompareSortedUnitsEncodingBatchSizes` from `Bool` to `Int32`.