### PR TITLE
Refactor encoder classes to support single observations

### DIFF
--- a/src/PointProcessDecoder.Core/Encoder/ClusterlessMarks.cs
+++ b/src/PointProcessDecoder.Core/Encoder/ClusterlessMarks.cs
@@ -71,12 +71,12 @@ public class ClusterlessMarks : ModelComponent, IEncoder
     {
         if (markChannels < 1)
         {
-            throw new ArgumentException("The number of mark channels must be greater than 0.");
+            throw new ArgumentException("The number of mark channels must be greater than 0.", nameof(markChannels));
         }
 
         if (markDimensions < 1)
         {
-            throw new ArgumentException("The number of mark dimensions must be greater than 0.");
+            throw new ArgumentException("The number of mark dimensions must be greater than 0.", nameof(markDimensions));
         }
 
         _device = device ?? CPU;
@@ -142,9 +142,8 @@ public class ClusterlessMarks : ModelComponent, IEncoder
                 break;
 
             default:
-                throw new ArgumentException("Invalid estimation method.");
-        }
-        ;
+                throw new ArgumentException("Invalid estimation method.", nameof(estimationMethod));
+        };
     }
 
     /// <inheritdoc/>
@@ -152,12 +151,12 @@ public class ClusterlessMarks : ModelComponent, IEncoder
     {
         if (marks.ndim != 3)
         {
-            throw new ArgumentException("The marks tensor must have 3 dimensions (numSamples, markDimensions, markChannels).");
+            throw new ArgumentException("The marks tensor must have 3 dimensions (numSamples, markDimensions, markChannels).", nameof(marks));
         }
 
         if (observations.ndim != 2)
         {
-            throw new ArgumentException("The observations tensor must have 2 dimensions (numSamples, observationDimensions).");
+            throw new ArgumentException("The observations tensor must have 2 dimensions (numSamples, observationDimensions).", nameof(observations));
         }
 
         var marksShape = marks.shape;
@@ -171,22 +170,22 @@ public class ClusterlessMarks : ModelComponent, IEncoder
 
         if (markDimensions != _markDimensions)
         {
-            throw new ArgumentException(nameof(marks), "The number of mark dimensions must match the shape of the marks tensor on dimension 1.");
+            throw new ArgumentException("The number of mark dimensions must match the shape of the marks tensor on dimension 1.", nameof(marks));
         }
 
         if (markChannels != _markChannels)
         {
-            throw new ArgumentException(nameof(marks), "The number of mark channels must match the shape of the marks tensor on dimension 2.");
+            throw new ArgumentException("The number of mark channels must match the shape of the marks tensor on dimension 2.", nameof(marks));
         }
 
         if (observationDimensions != _stateSpace.Dimensions)
         {
-            throw new ArgumentException(nameof(observations), "The number of observation dimensions must match the dimensions of the state space.");
+            throw new ArgumentException("The number of observation dimensions must match the dimensions of the state space.", nameof(observations));
         }
 
         if (numObservationSamples != numMarkSamples && numObservationSamples != 1)
         {
-            throw new ArgumentException(nameof(observations), "The number of samples in the observations and marks tensors must match, unless observations has only one sample.");
+            throw new ArgumentException("The number of samples in the observations and marks tensors must match, unless observations has only one sample.", nameof(observations));
         }
 
         _observationEstimation.Fit(observations);
@@ -198,8 +197,6 @@ public class ClusterlessMarks : ModelComponent, IEncoder
                 .sum(dim: 0)
                 .to(_device);
             _samples = numMarkSamples;
-            // _observationSamples = tensor(numObservationSamples, device: _device);
-
         }
         else
         {
@@ -207,7 +204,6 @@ public class ClusterlessMarks : ModelComponent, IEncoder
                 .any(dim: 1)
                 .sum(dim: 0);
             _samples += numMarkSamples;
-            // _observationSamples += numObservationSamples;
         }
 
         _rates = _spikeCounts.log() - _samples.log();

--- a/src/PointProcessDecoder.Core/IEncoder.cs
+++ b/src/PointProcessDecoder.Core/IEncoder.cs
@@ -1,4 +1,4 @@
-using static TorchSharp.torch;
+﻿using static TorchSharp.torch;
 
 namespace PointProcessDecoder.Core;
 

--- a/src/PointProcessDecoder.Core/PointProcessModel.cs
+++ b/src/PointProcessDecoder.Core/PointProcessModel.cs
@@ -1,4 +1,4 @@
-using static TorchSharp.torch;
+﻿using static TorchSharp.torch;
 
 using PointProcessDecoder.Core.Estimation;
 using PointProcessDecoder.Core.Transitions;
@@ -111,9 +111,9 @@ public class PointProcessModel : ModelBase, IModel
         _encoderModel = encoderType switch
         {
             EncoderType.ClusterlessMarks => new ClusterlessMarks(
-                estimationMethod: estimationMethod, 
+                estimationMethod: estimationMethod,
                 observationBandwidth: observationBandwidth,
-                markDimensions: markDimensions ?? 1, 
+                markDimensions: markDimensions ?? 1,
                 markChannels: markChannels ?? 1,
                 markBandwidth: markBandwidth ?? observationBandwidth,
                 stateSpace: _stateSpace,
@@ -123,7 +123,7 @@ public class PointProcessModel : ModelBase, IModel
                 scalarType: _scalarType
             ),
             EncoderType.SortedSpikes => new SortedSpikes(
-                estimationMethod: estimationMethod, 
+                estimationMethod: estimationMethod,
                 bandwidth: observationBandwidth,
                 nUnits: nUnits ?? 1,
                 stateSpace: _stateSpace,
@@ -198,15 +198,6 @@ public class PointProcessModel : ModelBase, IModel
     /// <inheritdoc/>
     public override void Encode(Tensor observations, Tensor inputs)
     {
-        if (observations.size(1) != _stateSpace.Dimensions)
-        {
-            throw new ArgumentException("The number of latent dimensions must match the shape of the observations.");
-        }
-        if (observations.size(0) != inputs.size(0))
-        {
-            throw new ArgumentException("The number of observations must match the number of inputs.");
-        }
-
         _encoderModel.Encode(observations, inputs);
     }
 
@@ -227,7 +218,7 @@ public class PointProcessModel : ModelBase, IModel
         };
 
         Directory.CreateDirectory(basePath);
-        
+
         using StreamWriter sw = new(Path.Combine(basePath, "configuration.json"));
         using JsonWriter writer = new JsonTextWriter(sw);
         serializer.Serialize(writer, _configuration);
@@ -239,7 +230,7 @@ public class PointProcessModel : ModelBase, IModel
     }
 
     /// <inheritdoc/>
-    public new static IModelComponent Load(string basePath, Device? device = null)
+    public static new IModelComponent Load(string basePath, Device? device = null)
     {
         // Check that the base path exists
         if (!Directory.Exists(basePath))
@@ -261,8 +252,8 @@ public class PointProcessModel : ModelBase, IModel
 
         using StreamReader sr = new(path);
         using JsonReader reader = new JsonTextReader(sr);
-        PointProcessModelConfiguration? configuration = serializer.Deserialize<PointProcessModelConfiguration>(reader) ?? throw new ArgumentException("The configuration file is empty.");
-        
+        var configuration = serializer.Deserialize<PointProcessModelConfiguration>(reader) ?? throw new ArgumentException("The configuration file is empty.");
+
         var model = new PointProcessModel(
             estimationMethod: configuration.EstimationMethod,
             transitionsType: configuration.TransitionsType,


### PR DESCRIPTION
This PR refactors the encoder model components to support encoding using observation and covariate tensors with different number of samples. In particular, it adds support for the case when only a single covariate sample is present, while many spike count samples or marks are provided with it.
